### PR TITLE
add `n_features` param to `permutation_importance()`

### DIFF
--- a/sklearn/inspection/_permutation_importance.py
+++ b/sklearn/inspection/_permutation_importance.py
@@ -146,6 +146,7 @@ def permutation_importance(
     random_state=None,
     sample_weight=None,
     max_samples=1.0,
+    n_features=None,
 ):
     """Permutation importance for feature evaluation [BRE]_.
 
@@ -229,6 +230,12 @@ def permutation_importance(
 
         .. versionadded:: 1.0
 
+    n_features : int or None, default=None
+        Number of features to include in the analysis, chosen randomly.
+        If None, all features will be included.
+
+        .. versionadded:: 1.0
+
     Returns
     -------
     result : :class:`~sklearn.utils.Bunch` or dict of such instances
@@ -276,6 +283,13 @@ def permutation_importance(
     random_state = check_random_state(random_state)
     random_seed = random_state.randint(np.iinfo(np.int32).max + 1)
 
+    if n_features is not None:
+        if n_features > X.shape[1]:
+            raise ValueError(f"n_features must be <= the number of features in X ({X.shape[1]}).")
+        feature_indices = random_state.choice(X.shape[1], size=n_features, replace=False)
+    else:
+        feature_indices = np.arange(X.shape[1])
+
     if not isinstance(max_samples, numbers.Integral):
         max_samples = int(max_samples * X.shape[0])
     elif max_samples > X.shape[0]:
@@ -296,7 +310,7 @@ def permutation_importance(
             scorer,
             max_samples,
         )
-        for col_idx in range(X.shape[1])
+        for col_idx in feature_indices
     )
 
     if isinstance(baseline_score, dict):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

add `n_features` param to enable a divide and conquer approach when you have 100's of features. Idea being to randomly cover n_features and do it multiple times in seperate work.

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
https://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
